### PR TITLE
Minor improvements to ftplibpp Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Build ftplibpp in library-gcc:
     cd ftplibpp
     make
    
+You can specify a path for 3rd party dependencies using the `EXT_PREFIX` variable. By
+default this is set to `/usr/local`. For example
+
+    # use 3rd party libraries installed in /opt/local
+    EXT_PREFIX=/opt/local make
+
 If you receive an error about openssl/ssh.h not being found:
 
     sudo apt-get install libssl-dev

--- a/ftplibpp/Makefile
+++ b/ftplibpp/Makefile
@@ -7,9 +7,12 @@ TARGETS = libftp++.a # libftp++.so
 OBJECTS = ftplib.o
 SOURCES = ftplib.cpp
 
-CPPFLAGS = -I. $(INCLUDES) $(DEFINES)
-CXXFLAGS = -Wall $(DEBUG) -I. $(INCLUDES)
-LDFLAGS = -L.
+EXT_PREFIX ?= /usr/local
+INSTALL_PREFIX ?= $(EXT_PREFIX)
+
+CPPFLAGS = -I. $(INCLUDES) -I$(EXT_PREFIX)/include $(DEFINES)
+LDFLAGS = -L. -L$(EXT_PREFIX)/lib
+CXXFLAGS = -Wall $(DEBUG)
 DEPFLAGS =
 
 UNAME := $(shell uname)
@@ -29,13 +32,13 @@ clean :
 	rm -f libftp.so.*
 
 uninstall :
-	rm -f /usr/local/lib/libftp.so.*
-	rm -f /usr/local/include/libftp.h
+	rm -f $(INSTALL_PREFIX)/lib/libftp.so.*
+	rm -f $(INSTALL_PREFIX)/include/libftp.h
 
 install : all
-	install -m 644 libftp.so.$(SOVERSION) /usr/local/lib
-	install -m 644 ftplib.h /usr/local/include
-	(cd /usr/local/lib && \
+	install -m 644 libftp.so.$(SOVERSION) $(INSTALL_PREFIX)/lib
+	install -m 644 ftplib.h $(INSTALL_PREFIX)/include
+	(cd $(INSTALL_PREFIX)/lib && \
 	 ln -sf libftp.so.$(SOVERSION) libftp.so.$(SONAME) && \
 	 ln -sf libftp.so.$(SONAME) libftp.so)
 

--- a/ftplibpp/Makefile
+++ b/ftplibpp/Makefile
@@ -7,7 +7,8 @@ TARGETS = libftp++.a # libftp++.so
 OBJECTS = ftplib.o
 SOURCES = ftplib.cpp
 
-CFLAGS = -Wall $(DEBUG) -I. $(INCLUDES) $(DEFINES)
+CPPFLAGS = -I. $(INCLUDES) $(DEFINES)
+CXXFLAGS = -Wall $(DEBUG) -I. $(INCLUDES)
 LDFLAGS = -L.
 DEPFLAGS =
 
@@ -39,21 +40,21 @@ install : all
 	 ln -sf libftp.so.$(SONAME) libftp.so)
 
 depend :
-	$(CC) $(CFLAGS) -M $(SOURCES) > .depend
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -M $(SOURCES) > .depend
 
 # build without -fPIC
 #unshared/ftplib.o: ftplib.cpp ftplib.h
 #	-mkdir unshared
-#	$(CC) -c $(CFLAGS) -D_REENTRANT $< -o $@
+#	$(CXX) -c $(CPPFLAGS) $(CXXFLAGS) -D_REENTRANT $< -o $@
 
 ftplib.o: ftplib.cpp ftplib.h
-	$(CC) -c $(CFLAGS) -fPIC -D_REENTRANT $< -o $@
+	$(CXX) -c $(CPPFLAGS) $(CXXFLAGS) -fPIC -D_REENTRANT $< -o $@
 
 libftp++.a: ftplib.o
 	ar -rcs $@ $<
 
 libftp.so.$(SOVERSION): ftplib.o
-	$(CC) -shared -Wl,-install_name,libftp.so.$(SONAME) $(LIBS) -lc -o $@ $<
+	$(CXX) -shared -Wl,-install_name,libftp.so.$(SONAME) $(LIBS) -lc -o $@ $<
 
 libftp++.so: libftp.so.$(SOVERSION)
 	ln -sf $< libftp.so.$(SONAME)


### PR DESCRIPTION
Minor improvements:

* Use standard make variables. This has the added advantage that they will be used by the implicit make rules to build e.g. `.o` files from `.cpp`.
* Add variable `EXT_PREFIX` to allow optional setting of location of 3rd library prefix path, allowing users to set for example `/opt/local` instead of the default `/usr/local`.
* Add variable `INSTALL_PREFIX` to set prefix of install path. This allows users to set a custom install prefix different to the default `$(EXT_PREFIX)`
* Update README.