### PR TITLE
Allow passing 3rd party install path to test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project includes the latest distribution of googletest, a subset of boost, 
 
 # Building
 
-If you already have the latest version of GoogleTest installed, you can update the CMakeLists.txt file in ./libraryTest to properly reference it (or an env variable). Or you can choose to build the included distribution of GoogleTest. One way to build it:
+If you already have the latest version of GoogleTest installed, you can update the CMakeLists.txt file in ./libraryTest to properly reference it (or use the EXT_PREFIX env variable). Or you can choose to build the included distribution of GoogleTest. One way to build it:
 
     cd googletest
     cmake .
@@ -27,8 +27,12 @@ If you receive an error about openssl/ssh.h not being found:
 
 You will likely receive some warnings when building ftplibpp.
 
-Run the bash script that builds and executes the tests:
+Run the bash script that builds and executes the tests.
 
     ./test
+
+Note that you can also optionally specify a path for 3rd party dependencies. For example
+
+    EXT_PATH=/opt/local ./test
 
 You should see well over 100 tests that are passing (green).

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -1,7 +1,14 @@
 project(library)
 cmake_minimum_required(VERSION 3.7)
 
-include_directories(../boost ./include ../ftplibpp)
+if (EXT_PREFIX)
+    include_directories(${EXT_PREFIX}/include)
+else()
+    include_directories(../boost)
+endif()
+
+include_directories(./include ../ftplibpp)
+
 add_definitions(-std=c++11)
 add_definitions(-DNOSSL)
 

--- a/libraryTest/CMakeLists.txt
+++ b/libraryTest/CMakeLists.txt
@@ -1,8 +1,17 @@
 project(libraryTest)
 cmake_minimum_required(VERSION 3.7)
 
-include_directories(../googletest/googlemock/include ../googletest/googletest/include ../boost ../library/include)
-link_directories(../googletest/googlemock ../googletest/googlemock/gtest ../library ../ftplibpp)
+if (EXT_PREFIX)
+    include_directories(${EXT_PREFIX}/include)
+    link_directories(${EXT_PREFIX}/lib)
+else()
+    include_directories(../googletest/googletest/include ../googletest/googlemock/include)
+    link_directories(../googletest/googlemock ../googletest/googlemock/gtest)
+endif()
+
+include_directories(../library/include)
+link_directories(../library ../ftplibpp)
+
 add_definitions(-std=c++11)
 
 set(sources 

--- a/test
+++ b/test
@@ -7,13 +7,13 @@ if [[ -e "library/LibraryTest" ]]; then
 fi
 pushd library
 if [[ ! -e "Makefile" ]]; then
-  cmake .
+  cmake -DEXT_PREFIX=${EXT_PREFIX} .
 fi
 make
 popd
 pushd libraryTest
 if [[ ! -e "Makefile" ]]; then
-  cmake .
+  cmake -DEXT_PREFIX=${EXT_PREFIX} .
 fi
 make
 ./libraryTest "$@"


### PR DESCRIPTION
As for the ftplibpp Makefile, use EXT_PREFIX to specify a single, optional
installation path for 3rd party libraries such as gtest and boost.

Note: this does not solve an issue with the test script where if one of
the CMakeLists.txt files of library or libraryTest are modified after
running the script, the changes are ignored and the previously generated
Makefile(s) get used. A more robust way to deal with these dependencies
would be via cmake find modules.