### PR TITLE
Build with GCC 4.8

### DIFF
--- a/library/FileReport.cpp
+++ b/library/FileReport.cpp
@@ -18,12 +18,12 @@ FileReport::FileReport(std::string filename): _filename{filename} {
 
 void FileReport::ftpGet() {
     ftplib ftp;
-    auto connect{ftp.Connect(FtpServer.c_str())};
+    auto connect = ftp.Connect(FtpServer.c_str());
     if (!connect) {
         throw runtime_error("unable to connect to " + FtpServer);
     }
     auto error{false};
-    auto loginSuccess{ftp.Login("ftp", "")};
+    auto loginSuccess = ftp.Login("ftp", "");
     if (!loginSuccess) {
         ftp.Quit();
         throw runtime_error("unable to log in");

--- a/library/FileReport.cpp
+++ b/library/FileReport.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <vector>
 #include <fstream>
+#include <stdexcept>
 
 #include "ftplib.h"
 

--- a/library/ReportUtil.cpp
+++ b/library/ReportUtil.cpp
@@ -9,20 +9,19 @@ using namespace std;
 string ReportUtil::transform(const string& x, int count, int spacing, StringOp op) {
     stringstream buffer;
     stringstream buffer1;
-    auto w{count + spacing};
+    auto w = count + spacing;
     string pads;
     switch (op) {
         case StringOp::under:
             {
-                auto i{0};
-                for (; i < w - spacing; i++) {
+                for (auto i = 0; i < w - spacing; i++) {
                     buffer << '-';
                 }
                 string ptext{buffer.str()};
                 pads = "";
                 buffer1 << ptext;
-                auto l{w - ptext.length()};
-                for (auto j{0}; j < l; j++) {
+                auto l = w - ptext.length();
+                for (auto j = 0; j < l; j++) {
                     pads += " ";
                 }
                 buffer1 << pads;
@@ -31,7 +30,7 @@ string ReportUtil::transform(const string& x, int count, int spacing, StringOp o
         case StringOp::pad:
             {
                 pads = " ";
-                auto l{spacing};
+                auto l = spacing;
                 while (l > 1) {
                     pads = pads + " ";
                     l = l - 1;

--- a/library/include/InventoryReport.h
+++ b/library/include/InventoryReport.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <exception>
 #include <sstream>
+#include <stdexcept>
 
 class LibraryOfCongressAPI {
 public:

--- a/library/include/VoteEngine.h
+++ b/library/include/VoteEngine.h
@@ -8,13 +8,13 @@
 class VoteEngine {
 public:
     void accept(const Vote& vote) {
-        auto currentCount{_counts[vote._messageId]};
-        auto delta{vote._isUpvote ? 1 : -1};
+        auto currentCount = _counts[vote._messageId];
+        auto delta = vote._isUpvote ? 1 : -1;
         _counts[vote._messageId] = currentCount + delta;
     }
 
     int count(unsigned int messageId) const {
-        auto it{_counts.find(messageId)};
+        auto it = _counts.find(messageId);
         if (it == _counts.end()) return 0;
         return it->second;
     }

--- a/libraryTest/AccountTest.cpp
+++ b/libraryTest/AccountTest.cpp
@@ -10,16 +10,16 @@ using namespace testing;
 
 TEST(AnAccount, DISABLED_IncreasesBalanceOnDeposit) {
     int concurrentThreads{8};
-    auto its{10000};
-    auto amount{1000};
-    for (auto i{0}; i < its; i++) {
+    auto its = 10000;
+    auto amount = 1000;
+    for (auto i = 0; i < its; i++) {
        Account account;
        vector<thread> threads;
        for (int i = 0; i < concurrentThreads; ++i)
             threads.push_back(thread(&Account::deposit, &account, amount));
        for (auto& t: threads) t.join();
 
-       auto val{account.balance()};
+       auto val = account.balance();
 
        ASSERT_THAT(val, Eq(concurrentThreads * amount));
     }

--- a/libraryTest/CatalogTest.cpp
+++ b/libraryTest/CatalogTest.cpp
@@ -50,8 +50,8 @@ TEST_F(CatalogTest, ContainsAnswersFalseWhenNotFound) {
 
 TEST_F(CatalogTest, AddedHoldingCanBeRetrieved) {
     catalog.add(*theTrialHolding);
-    auto barcode{Holding::constructBarcode(
-      theTrialHolding->classification(), theTrialHolding->copyNumber())};
+    auto barcode = Holding::constructBarcode(
+      theTrialHolding->classification(), theTrialHolding->copyNumber());
 
     ASSERT_THAT(catalog.contains(barcode), Eq(true));
 }

--- a/libraryTest/ExamplesTest.cpp
+++ b/libraryTest/ExamplesTest.cpp
@@ -152,7 +152,7 @@ void completeSale() {
     _total = 0.0;
     _totalOfDiscountedItems = 0.0;
     for (auto item : _purchases) {
-        auto itemTotal{0.0};
+        auto itemTotal = 0.0;
         stringstream message;
         if (item.isDiscountable()) {
             auto discounted = item.price() * (1 - _memberDiscount);
@@ -189,7 +189,7 @@ void completeSale() {
     _total = 0.0;
     _totalOfDiscountedItems = 0.0;
     for (auto item : _purchases) {
-        auto itemTotal{0.0};
+        auto itemTotal = 0.0;
         stringstream message;
         if (item.isDiscountable()) {
             _totalOfDiscountedItems += discountedPrice(item);

--- a/libraryTest/HoldingServiceTest.cpp
+++ b/libraryTest/HoldingServiceTest.cpp
@@ -83,7 +83,7 @@ TEST_F(HoldingServiceTest, DeleteAllSetsSizeToZero) {
 }
 
 TEST_F(HoldingServiceTest, AddInitializesBranch) {
-    auto barcode{HoldingBarcode(THE_TRIAL_CLASSIFICATION, 1).asString()};
+    auto barcode = HoldingBarcode(THE_TRIAL_CLASSIFICATION, 1).asString();
     holdingService.addAtBranch(branch1->id(), barcode);
 
     auto holding = holdingService.findByBarCode(barcode);
@@ -92,11 +92,11 @@ TEST_F(HoldingServiceTest, AddInitializesBranch) {
 }
 
 TEST_F(HoldingServiceTest, RetrievesAddedHolding) {
-    auto barcode{HoldingBarcode(THE_TRIAL_CLASSIFICATION, 1).asString()};
+    auto barcode = HoldingBarcode(THE_TRIAL_CLASSIFICATION, 1).asString();
 
     holdingService.addAtBranch(branch1->id(), barcode);
 
-    auto holding{holdingService.findByBarCode(barcode)};
+    auto holding = holdingService.findByBarCode(barcode);
     ASSERT_THAT(holding.barcode(), StrEq(barcode));
 }
 
@@ -105,19 +105,19 @@ TEST_F(HoldingServiceTest, ExistsReturnsFalseWhenNotFound) {
 }
 
 TEST_F(HoldingServiceTest, ExistsReturnsTrueWhenNotFound) {
-    auto barcode{Holding::constructBarcode(CATCH22_CLASSIFICATION, 1)};
+    auto barcode = Holding::constructBarcode(CATCH22_CLASSIFICATION, 1);
     holdingService.addAtBranch(branch1->id(), barcode);
 
-    auto found{holdingService.existsWithBarcode(barcode)};
+    auto found = holdingService.existsWithBarcode(barcode);
 
     ASSERT_THAT(found, Eq(true));
 }
 
 TEST_F(HoldingServiceTest, IsAvailableReturnsTrueWhenHoldingAvailable) {
-    auto barcode{Holding::constructBarcode(CATCH22_CLASSIFICATION, 1)};
+    auto barcode = Holding::constructBarcode(CATCH22_CLASSIFICATION, 1);
     holdingService.addAtBranch(branch1->id(), barcode);
 
-    auto isAvailable{holdingService.isAvailable(barcode)};
+    auto isAvailable = holdingService.isAvailable(barcode);
 
     ASSERT_THAT(isAvailable, Eq(true));
 }
@@ -127,7 +127,7 @@ TEST_F(HoldingServiceTest, IsAvailableReturnsFalseWhenHoldingCheckedOut) {
     HoldingBarcode barcode(THE_TRIAL_CLASSIFICATION, 1);
     CheckOut(barcode, branch1);
 
-    auto isAvailable{holdingService.isAvailable(barcode.asString())};
+    auto isAvailable = holdingService.isAvailable(barcode.asString());
 
     ASSERT_THAT(isAvailable, Eq(false));
 }
@@ -154,7 +154,7 @@ TEST_F(HoldingServiceTest, FindByClassificationReturnsMultipleMatches) {
 }
 
 TEST_F(HoldingServiceTest, Transfer) {
-    auto barcode{Holding::constructBarcode(CATCH22_CLASSIFICATION, 1)};
+    auto barcode = Holding::constructBarcode(CATCH22_CLASSIFICATION, 1);
     holdingService.addAtBranch(branch1->id(), barcode);
 
     holdingService.transfer(barcode, branch1->id());
@@ -163,19 +163,19 @@ TEST_F(HoldingServiceTest, Transfer) {
 }
 
 TEST_F(HoldingServiceTest, CheckedOutHoldingUnavailable) {
-    auto barcode{HoldingBarcode{CATCH22_CLASSIFICATION, 1}.asString()};
+    auto barcode = HoldingBarcode{CATCH22_CLASSIFICATION, 1}.asString();
     holdingService.addAtBranch(branch1->id(), barcode);
     patronService.add(Patron{"", "p1001"});
 
     holdingService.checkOut("p1001", barcode, *arbitraryDate);
 
-    auto retrieved{holdingService.findByBarCode(barcode)};
+    auto retrieved = holdingService.findByBarCode(barcode);
     ASSERT_THAT(retrieved.isAvailable(), Eq(false));
 }
 
 TEST_F(HoldingServiceTest, CheckedOutBooksAddedToPatron) {
     holdingService.addAtBranch(branch1->id(), HoldingBarcode(CATCH22_CLASSIFICATION, 1).asString());
-    auto barcode{HoldingBarcode(CATCH22_CLASSIFICATION, 1).asString()};
+    auto barcode = HoldingBarcode(CATCH22_CLASSIFICATION, 1).asString();
     patronService.add(Patron{"", "p1001"});
 
     holdingService.checkOut("p1001", HoldingBarcode(CATCH22_CLASSIFICATION, 1).asString(), *arbitraryDate);

--- a/libraryTest/PersistenceTest.cpp
+++ b/libraryTest/PersistenceTest.cpp
@@ -27,7 +27,7 @@ TEST_P(PersistenceTest, SizeIncrementsWithEachAdd) {
 }
 
 TEST_P(PersistenceTest, ReturnsNullPointerWhenItemNotFound) {
-    auto found{persister->get("1")};
+    auto found = persister->get("1");
 
     TestSerializable* serializable = found.get();
 

--- a/libraryTest/VoteTest.cpp
+++ b/libraryTest/VoteTest.cpp
@@ -71,8 +71,8 @@ TEST_F(AVoteEngine, DISABLED_IgnoresMultipleUpvotesOnSameMessage) {
 }
 
 TEST_F(AVoteEngine, DISABLED_SupportsConcurrency) {
-    auto its{10000};
-    auto concurrentThreadPairs{1};
+    auto its = 10000;
+    auto concurrentThreadPairs = 1;
     vector<thread> threads;
     for (int i = 0; i < concurrentThreadPairs; i++) {
         threads.push_back(thread([&]() { downvote(its); }));
@@ -80,7 +80,7 @@ TEST_F(AVoteEngine, DISABLED_SupportsConcurrency) {
     }
     for (auto& t: threads) t.join();
 
-    auto count{engine.count(AMessageId)};
+    auto count = engine.count(AMessageId);
 
     ASSERT_THAT(count, Eq(0));
 }

--- a/libraryTest/main.cpp
+++ b/libraryTest/main.cpp
@@ -121,8 +121,8 @@ public:
 };
 
 bool hasShowFailuresOnlyOption(int argc, char **argv) {
-    auto showFailuresOnly{false};
-    for (unsigned int i{1}; i < argc; i++) {
+    auto showFailuresOnly = false;
+    for (unsigned int i = 1; i < argc; i++) {
         auto option = string{argv[i]};
         if (option == "--failed-only")
             showFailuresOnly = true;
@@ -135,7 +135,7 @@ int main(int argc, char **argv) {
 
     ::testing::InitGoogleTest(&argc, argv);
 
-    auto showFailuresOnly{hasShowFailuresOnlyOption(argc, argv)};
+    auto showFailuresOnly = hasShowFailuresOnlyOption(argc, argv);
 
     // remove the default listener
     testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();


### PR DESCRIPTION
I still use GCC 4.8 on my machine(s) (Ubuntu 14.04 default compiler), so I noticed compilation errors of two kinds:
- `error: ‘runtime_error’ was not declared in this scope` which is fixed by including `stdexcept`
- `error: no match for ‘operator!’ (operand type is ‘std::initializer_list<int>’)`, the compiler seems unable to infer the type from an expression `auto x{y}`, so I had to switch these to use assignments.

This PR fixes these.