### PR TITLE
Add a minimal top-level cmakefile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.8)
+
+add_subdirectory(library)
+add_subdirectory(libraryTest)

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -42,4 +42,6 @@ set(sources
    )
 add_library(library ${sources})
 target_link_libraries(library pthread)
-target_link_libraries(library rt)
+if(NOT APPLE)
+   target_link_libraries(library rt)
+endif()


### PR DESCRIPTION
This should replace the `test` script as follows:

```
mkdir build
cd build
cmake ..
make && ./libraryTest/libraryTest
```